### PR TITLE
Feat: Add a basic levelUp upgrade system

### DIFF
--- a/Assets/Resources/Configs/LevelUp.meta
+++ b/Assets/Resources/Configs/LevelUp.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b84e4ec311084e541a58196065160daa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Configs/LevelUp/Level1.asset
+++ b/Assets/Resources/Configs/LevelUp/Level1.asset
@@ -9,12 +9,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e4018fd6bf07f484caa3ae46af2bfb72, type: 3}
-  m_Name: LifeSteal
+  m_Script: {fileID: 11500000, guid: 1d22adbcee09af1489de24718458b57d, type: 3}
+  m_Name: Level1
   m_EditorClassIdentifier: 
-  powerUpPrefab: {fileID: 6808692802758872443, guid: b619557233782074988e1be12ae065b1, type: 3}
-  dropNumber: 1
-  timeToLive: 15
-  duration: 2.1474836e+9
-  boostAmount: 100
-  isStackable: 0
+  level: 0
+  healthIncrease: 0
+  speedIncrease: 0
+  damageIncrease: 0
+  critRateIncrease: 0
+  critDamageIncrease: 0
+  additionalOptions:
+  - Test1
+  - Test2

--- a/Assets/Resources/Configs/LevelUp/Level1.asset.meta
+++ b/Assets/Resources/Configs/LevelUp/Level1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9169f2382241a9248966f56ecac743d1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Configs/LevelUp/LevelUpConfig.asset
+++ b/Assets/Resources/Configs/LevelUp/LevelUpConfig.asset
@@ -9,12 +9,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e4018fd6bf07f484caa3ae46af2bfb72, type: 3}
-  m_Name: LifeSteal
+  m_Script: {fileID: 11500000, guid: 7130e18aee2f82740b766bad6b07578d, type: 3}
+  m_Name: LevelUpConfig
   m_EditorClassIdentifier: 
-  powerUpPrefab: {fileID: 6808692802758872443, guid: b619557233782074988e1be12ae065b1, type: 3}
-  dropNumber: 1
-  timeToLive: 15
-  duration: 2.1474836e+9
-  boostAmount: 100
-  isStackable: 0
+  allLevelUpConfigList:
+  - {fileID: 11400000, guid: 9169f2382241a9248966f56ecac743d1, type: 2}

--- a/Assets/Resources/Configs/LevelUp/LevelUpConfig.asset.meta
+++ b/Assets/Resources/Configs/LevelUp/LevelUpConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27ab9b7d9dcf32a4cad9cb088a7458ae
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/UI.unity
+++ b/Assets/Scenes/UI.unity
@@ -3093,6 +3093,7 @@ MonoBehaviour:
   allDropItemConfig: {fileID: 11400000, guid: 20a183ad6a998ab43965f56d4f7107a5, type: 2}
   playerConfig: {fileID: 11400000, guid: 2aa4ff2f49b57754b89c8a1520ebe077, type: 2}
   characterPrefab: {fileID: 7902174039242817089, guid: eb315ad2f4977474fa487a3025c7bd73, type: 3}
+  AllLevelUpConfig: {fileID: 11400000, guid: 27ab9b7d9dcf32a4cad9cb088a7458ae, type: 2}
   sceneUpdater: {fileID: 0}
   isPause: 0
   isHost: 0

--- a/Assets/Scripts/Config/AllLevelUpConfig.cs
+++ b/Assets/Scripts/Config/AllLevelUpConfig.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "LevelUpConfig", menuName = "Config/AllLevelUpConfig")]
+public class AllLevelUpConfig : ScriptableObject
+{
+    public List<LevelUpConfig> allLevelUpConfigList = new List<LevelUpConfig>();
+}

--- a/Assets/Scripts/Config/AllLevelUpConfig.cs.meta
+++ b/Assets/Scripts/Config/AllLevelUpConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7130e18aee2f82740b766bad6b07578d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Config/LevelUps.meta
+++ b/Assets/Scripts/Config/LevelUps.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 483d88605e905614b9e0295b67000318
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Config/LevelUps/Level1.cs
+++ b/Assets/Scripts/Config/LevelUps/Level1.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+[CreateAssetMenu(menuName = "Config/LevelUpConfig/Level1")]
+public class Level1 : LevelUpConfig
+{
+    public override int[] getHealthIncrements() { return new int[] { 100, 200, 300 }; }
+    public override float[] getSpeedIncrements() { return new float[] { 100f, 100f, 100f }; }
+    public override float[] getDamageIncrements() { return new float[] { 100f, 200f }; }
+    public override float[] getCritRateIncrements() { return new float[] { 0.03f, 0.06f}; }
+    public override float[] getCritDamageIncrements() { return new float[] { 0.06f, 0.12f}; }
+    public Level1()
+    {
+        additionalOptions.Add("Test1");
+        additionalOptions.Add("Test2");
+    }
+    public override void ApplyAdditional(string buff)
+    {
+        Debug.Log("ApplyAdditional level1");
+        base.ApplyAdditional(buff);
+        switch (buff)
+        {
+            case "Test1":
+                Debug.Log("Test1");
+                break;
+            case "Test2":
+                Debug.Log("Test2");
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/Assets/Scripts/Config/LevelUps/Level1.cs
+++ b/Assets/Scripts/Config/LevelUps/Level1.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class Level1 : LevelUpConfig
 {
     public override int[] getHealthIncrements() { return new int[] { 100, 200, 300 }; }
-    public override float[] getSpeedIncrements() { return new float[] { 100f, 100f, 100f }; }
+    public override float[] getSpeedIncrements() { return new float[] { 0.05f, 0.1f, 0.15f }; }
     public override float[] getDamageIncrements() { return new float[] { 100f, 200f }; }
     public override float[] getCritRateIncrements() { return new float[] { 0.03f, 0.06f}; }
     public override float[] getCritDamageIncrements() { return new float[] { 0.06f, 0.12f}; }
@@ -14,20 +14,24 @@ public class Level1 : LevelUpConfig
         additionalOptions.Add("Test1");
         additionalOptions.Add("Test2");
     }
-    public override void ApplyAdditional(string buff)
+    public override void ApplyAdditional(string buff = "")
     {
         Debug.Log("ApplyAdditional level1");
-        base.ApplyAdditional(buff);
+        // base.ApplyAdditional(buff);
         switch (buff)
         {
             case "Test1":
-                Debug.Log("Test1");
+                Debug.Log("Test1 applied");
+                // Apply Test1 effect here
                 break;
             case "Test2":
-                Debug.Log("Test2");
+                Debug.Log("Test2 applied");
+                // Apply Test2 effect here
                 break;
             default:
+                Debug.Log("No buff applied");
                 break;
         }
     }
 }
+

--- a/Assets/Scripts/Config/LevelUps/Level1.cs.meta
+++ b/Assets/Scripts/Config/LevelUps/Level1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d22adbcee09af1489de24718458b57d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Config/LevelUps/LevelUpConfig.cs
+++ b/Assets/Scripts/Config/LevelUps/LevelUpConfig.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LevelUpConfig : ScriptableObject
+{
+    //every player start at level ONE ()
+    public int level;
+    // all of the increase value below are general for ALL level. 
+    // each level may have other specific increase value.
+    public int healthIncrease;
+    public float speedIncrease;
+    public float damageIncrease;
+    public float critRateIncrease;
+    public float critDamageIncrease;
+    public List<string> additionalOptions = new List<string>();
+
+    // a list of some random weighted level up increments
+    public virtual int[] getHealthIncrements() { return new int[] { }; }
+    public virtual float[] getSpeedIncrements() { return new float[] { }; }
+    public virtual float[] getDamageIncrements() { return new float[] { }; }
+    public virtual float[] getCritRateIncrements() { return new float[] { }; }
+    public virtual float[] getCritDamageIncrements() { return new float[] { }; }
+    List<string> finalOptions = new List<string>();
+    public virtual void RandomLevelUpChoice()
+    {
+        finalOptions.Clear(); // Clear for each level
+        List<string> defaultOptions = new List<string> { "health", "speed", "damage", "crit" };
+        defaultOptions.AddRange(additionalOptions);
+
+        while (finalOptions.Count < 3)
+        {
+            string option = defaultOptions[Random.Range(0, defaultOptions.Count)];
+            if (!finalOptions.Contains(option))
+            {
+                finalOptions.Add(option);
+            }
+        }
+        Debug.Log("final options are: " + string.Join(", ", finalOptions.ToArray()));
+    }
+
+    public virtual void ApplyDefault()
+    {
+        foreach (string option in finalOptions)
+        {
+            switch (option)
+            {
+                case "health":
+                Debug.Log("Level up: Health increased by " + getHealthIncrements()[Random.Range(0, getHealthIncrements().Length)]);
+                    healthIncrease += getHealthIncrements()[Random.Range(0, getHealthIncrements().Length)];
+                    break;
+                case "speed":
+                Debug.Log("Level up: Speed increased by " + getSpeedIncrements()[Random.Range(0, getSpeedIncrements().Length)]);
+                    speedIncrease += getSpeedIncrements()[Random.Range(0, getSpeedIncrements().Length)];
+                    break;
+                case "damage":
+                Debug.Log("Level up: Damage increased by " + getDamageIncrements()[Random.Range(0, getDamageIncrements().Length)]);
+                    damageIncrease += getDamageIncrements()[Random.Range(0, getDamageIncrements().Length)];
+                    break;
+                case "crit":
+                Debug.Log("Level up: Crit rate increased by " + getCritRateIncrements()[Random.Range(0, getCritRateIncrements().Length)] + " and Crit damage increased by " + getCritDamageIncrements()[Random.Range(0, getCritDamageIncrements().Length)]);
+                    critRateIncrease += getCritRateIncrements()[Random.Range(0, getCritRateIncrements().Length)];
+                    critDamageIncrease += getCritDamageIncrements()[Random.Range(0, getCritDamageIncrements().Length)];
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    public virtual void ApplyAdditional(string buff = "")
+    {
+        Debug.Log("Applying additional options");
+    }
+    public virtual void ApplyChoice()
+    {
+        RandomLevelUpChoice();
+        ApplyDefault();
+        ApplyAdditional();
+    }
+}

--- a/Assets/Scripts/Config/LevelUps/LevelUpConfig.cs
+++ b/Assets/Scripts/Config/LevelUps/LevelUpConfig.cs
@@ -36,10 +36,9 @@ public class LevelUpConfig : ScriptableObject
                 finalOptions.Add(option);
             }
         }
-        Debug.Log("final options are: " + string.Join(", ", finalOptions.ToArray()));
     }
 
-    public virtual void ApplyDefault()
+    public virtual void ApplyDefault(string buff = "")
     {
         foreach (string option in finalOptions)
         {
@@ -63,6 +62,7 @@ public class LevelUpConfig : ScriptableObject
                     critDamageIncrease += getCritDamageIncrements()[Random.Range(0, getCritDamageIncrements().Length)];
                     break;
                 default:
+                    Debug.Log("No buff applied");
                     break;
             }
         }
@@ -71,10 +71,20 @@ public class LevelUpConfig : ScriptableObject
     {
         Debug.Log("Applying additional options");
     }
+    //TODO: implement this for each level up UI (player choose) @Quoc
+    public virtual string FinalChoice()
+    {
+        Debug.Log("final options list are: " + string.Join(", ", finalOptions.ToArray()));
+        string chosenOption = finalOptions[Random.Range(0, finalOptions.Count)];
+        Debug.Log("Chosen option: " + chosenOption);
+        return chosenOption;
+    }
     public virtual void ApplyChoice()
     {
         RandomLevelUpChoice();
-        ApplyDefault();
-        ApplyAdditional();
+        var chosen = FinalChoice();
+        ApplyDefault(chosen);
+        ApplyAdditional(chosen);
     }
+
 }

--- a/Assets/Scripts/Config/LevelUps/LevelUpConfig.cs.meta
+++ b/Assets/Scripts/Config/LevelUps/LevelUpConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77aa659732b29714a90a9450e37698ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GamePlay/AllManager.cs
+++ b/Assets/Scripts/GamePlay/AllManager.cs
@@ -12,6 +12,7 @@ public class AllManager : MonoBehaviour
     [SerializeField] public AllDropItemConfig allDropItemConfig;
     [SerializeField] public PlayerConfig playerConfig;
     [SerializeField] GameObject characterPrefab;
+    [SerializeField] AllLevelUpConfig AllLevelUpConfig;
     public SceneUpdater sceneUpdater;
     public BulletManager bulletManager;
     public CreepManager creepManager;
@@ -30,7 +31,7 @@ public class AllManager : MonoBehaviour
     }
     private void Start()
     {
-        playerManager = new PlayerManager(characterPrefab);
+        playerManager = new PlayerManager(characterPrefab, AllLevelUpConfig);
     }
     private void Update()
     {

--- a/Assets/Scripts/GamePlay/PlayerManager.cs
+++ b/Assets/Scripts/GamePlay/PlayerManager.cs
@@ -67,7 +67,7 @@ public class Player
         foreach (var powerUp in activePowerUps.Keys.ToList())
         {
             activePowerUps[powerUp] -= Time.deltaTime;
-            Debug.Log($"Power-up: {powerUp} has {activePowerUps[powerUp]}s left");
+            // Debug.Log($"Power-up: {powerUp} has {activePowerUps[powerUp]}s left");
             if (activePowerUps[powerUp] <= 0)
             {
                 expiredPowerUps.Add(powerUp);
@@ -113,9 +113,11 @@ public class PlayerManager
 {
     public Dictionary<string, Player> dictPlayers = new Dictionary<string, Player>();
     GameObject characterPrefab;
-    public PlayerManager(GameObject characterPrefab)
+    public AllLevelUpConfig allLevelUpConfig;
+    public PlayerManager(GameObject characterPrefab, AllLevelUpConfig levelUpConfig)
     {
         this.characterPrefab = characterPrefab;
+        this.allLevelUpConfig = levelUpConfig;
     }
     public int exp = 0;
     public int level = Constants.PlayerBaseLevel;
@@ -154,6 +156,10 @@ public class PlayerManager
                 Player player = pair.Value;
                 player.health = GetMaxHealthFromLevel();
                 player.levelUpEffect = GameObject.Instantiate(player.playerConfig.levelUpEffect, player.playerTrans.position, Quaternion.identity);
+
+                LevelUpConfig levelUpConfig = allLevelUpConfig.allLevelUpConfigList[Mathf.Min(level - 1, allLevelUpConfig.allLevelUpConfigList.Count - 1)];
+                levelUpConfig.ApplyChoice();
+                ApplyLevelUpConfig(levelUpConfig);
             }
         }
             
@@ -314,6 +320,15 @@ public class PlayerManager
         {
             Debug.Log("Hut dc 1 mau nha may em yeu");
             AllManager.Instance().playerManager.dictPlayers[Player_ID.MyPlayerID].health++;
+        }
+    }
+    public void ApplyLevelUpConfig(LevelUpConfig levelUpConfig)
+    {
+        foreach (var player in dictPlayers.Values)
+        {
+            player.health += levelUpConfig.healthIncrease;
+            player.SetSpeedBoost(levelUpConfig.speedIncrease);
+            player.SetDamageBoost(levelUpConfig.damageIncrease);
         }
     }
 }

--- a/Assets/Scripts/GamePlay/PlayerManager.cs
+++ b/Assets/Scripts/GamePlay/PlayerManager.cs
@@ -327,7 +327,7 @@ public class PlayerManager
         foreach (var player in dictPlayers.Values)
         {
             player.health += levelUpConfig.healthIncrease;
-            player.SetSpeedBoost(levelUpConfig.speedIncrease);
+            // player.SetSpeedBoost(levelUpConfig.speedIncrease);
             player.SetDamageBoost(levelUpConfig.damageIncrease);
         }
     }


### PR DESCRIPTION
## Descriptions:
- Add a basic level up system.
- Use a scriptable object and configs to modify for each level.
- Currently, using a random generator to choose between pre-define buff for each level, then use another random generator to "pick" one of the three.
## Motivation:
- To expand the level-up system, add a potential "build path" for players.
## Testing Done:
- When player level up, character get the pre-define buff
- Only have level1 for all testing at the moment