### PR TITLE
fix: creep always drop item no matter the chance

### DIFF
--- a/Assets/Resources/Configs/Creep/Creep1Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep1Config.asset
@@ -19,6 +19,14 @@ MonoBehaviour:
   exp: 10
   dropItemConfigs:
   - powerUpType: 0
-    dropChance: 0
+    dropChance: 0.1
   - powerUpType: 12
-    dropChance: 1
+    dropChance: 0.1
+  - powerUpType: 1
+    dropChance: 0.1
+  - powerUpType: 4
+    dropChance: 0.1
+  - powerUpType: 11
+    dropChance: 0.1
+  - powerUpType: 2
+    dropChance: 0.1

--- a/Assets/Resources/Configs/Creep/Creep2Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep2Config.asset
@@ -19,8 +19,16 @@ MonoBehaviour:
   exp: 15
   dropItemConfigs:
   - powerUpType: 0
-    dropChance: 0
+    dropChance: 0.2
   - powerUpType: 12
-    dropChance: 1
+    dropChance: 0.1
+  - powerUpType: 1
+    dropChance: 0.1
+  - powerUpType: 4
+    dropChance: 0.1
+  - powerUpType: 11
+    dropChance: 0.1
+  - powerUpType: 2
+    dropChance: 0.2
   bulletConfig: {fileID: 11400000, guid: 6a1dae1fb069c1945bd6abbed9c0dea7, type: 2}
   fireRate: 5

--- a/Assets/Resources/Configs/Creep/Creep3Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep3Config.asset
@@ -19,8 +19,14 @@ MonoBehaviour:
   exp: 20
   dropItemConfigs:
   - powerUpType: 0
-    dropChance: 0
+    dropChance: 0.1
   - powerUpType: 12
-    dropChance: 1
+    dropChance: 0.2
+  - powerUpType: 1
+    dropChance: 0.2
+  - powerUpType: 4
+    dropChance: 0.2
+  - powerUpType: 11
+    dropChance: 0.2
   bulletConfig: {fileID: 11400000, guid: 5a6237f2bc2e34c489335df2f29de9fe, type: 2}
   fireRate: 7

--- a/Assets/Resources/Configs/Creep/Creep4Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep4Config.asset
@@ -19,8 +19,14 @@ MonoBehaviour:
   exp: 30
   dropItemConfigs:
   - powerUpType: 0
-    dropChance: 0
+    dropChance: 0.1
   - powerUpType: 12
-    dropChance: 1
+    dropChance: 0.2
+  - powerUpType: 1
+    dropChance: 0.2
+  - powerUpType: 4
+    dropChance: 0.2
+  - powerUpType: 11
+    dropChance: 0.2
   startIncreaseSpeedDis: 5
   speedMultiplayer: 1.5

--- a/Assets/Resources/Configs/Creep/Creep5Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep5Config.asset
@@ -19,7 +19,13 @@ MonoBehaviour:
   exp: 100
   dropItemConfigs:
   - powerUpType: 0
-    dropChance: 0
+    dropChance: 0.1
   - powerUpType: 12
-    dropChance: 1
+    dropChance: 0.2
+  - powerUpType: 1
+    dropChance: 0.2
+  - powerUpType: 4
+    dropChance: 0.2
+  - powerUpType: 11
+    dropChance: 0.2
   explosion: {fileID: 1535640691960112, guid: b345030ffc29a664cad1d2a6e384a252, type: 3}

--- a/Assets/Resources/Configs/Creep/Creep6Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep6Config.asset
@@ -15,12 +15,18 @@ MonoBehaviour:
   creepPrefab: {fileID: 4473772703222537841, guid: c8f30a276b03c6f478e2e8921db10a71, type: 3}
   baseHp: 100
   baseSpeed: 2
-  baseDmg: 100
+  baseDmg: 0
   exp: 20
   dropItemConfigs:
   - powerUpType: 0
-    dropChance: 0
+    dropChance: 0.1
   - powerUpType: 12
-    dropChance: 1
+    dropChance: 0.2
+  - powerUpType: 1
+    dropChance: 0.2
+  - powerUpType: 4
+    dropChance: 0.2
+  - powerUpType: 11
+    dropChance: 0.2
   skillCD: 7
   meteor: {fileID: 1839445213900760, guid: 23f972538c5ab5b4f94000c5657b9754, type: 3}

--- a/Assets/Resources/Configs/Creep/Creep7Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep7Config.asset
@@ -19,9 +19,15 @@ MonoBehaviour:
   exp: 30
   dropItemConfigs:
   - powerUpType: 0
-    dropChance: 0
+    dropChance: 0.1
   - powerUpType: 12
-    dropChance: 1
+    dropChance: 0.2
+  - powerUpType: 1
+    dropChance: 0.2
+  - powerUpType: 4
+    dropChance: 0.2
+  - powerUpType: 11
+    dropChance: 0.2
   startMoveAwayDistance: 5
   healing: {fileID: 9017484664307500583, guid: 016eb712ee010394aa2dd710d9003fc6, type: 3}
   skillCD: 10

--- a/Assets/Resources/Configs/PowerUps/SpeedBoost.asset
+++ b/Assets/Resources/Configs/PowerUps/SpeedBoost.asset
@@ -16,5 +16,5 @@ MonoBehaviour:
   dropNumber: 1
   timeToLive: 15
   duration: 15
-  boostAmount: 5
+  boostAmount: 0.5
   isStackable: 0

--- a/Assets/Scripts/Config/Creep/CreepConfig.cs
+++ b/Assets/Scripts/Config/Creep/CreepConfig.cs
@@ -98,15 +98,16 @@ public class CreepConfig : ScriptableObject
     }
     private AllDropItemConfig.PowerUpsType? DetermineDrop()
     {
-        float totalDropChance = dropItemConfigs.Sum(config => config.dropChance);
+        float totalDropChance = 1;
         float roll = Random.Range(0, totalDropChance);
         float cumulative = 0f;
-
+        Debug.Log("Roll: " + roll);
         foreach (var config in dropItemConfigs)
         {
             cumulative += config.dropChance;
             if (roll < cumulative)
             {
+                Debug.Log("Dropped: " + config.powerUpType);
                 return config.powerUpType;
             }
         }


### PR DESCRIPTION
## Descriptions:
- Fix creep always spawn pickup even when the cumulative drop rate is less than 1. 
## Motivation:
- Its a bug 
## Testing Done:
Test on multiple creeps